### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ installed by all the same methods for installing Clang 5 or later.
 With macOs, the easiest way is to install via Homebrew.
 
 ``` shell
-brew install llvm
+brew install llvm --HEAD
 ```
 
 ## Enabling `lsp-clangd`


### PR DESCRIPTION
for macos sierra a simple brew install llvm doesnt include the standard libraries on the search path. This is fixed in HEAD. The update to the README.md installation instructions reflect this.