### PR TITLE
Let lsp-clangd be better configured

### DIFF
--- a/lsp-clangd.el
+++ b/lsp-clangd.el
@@ -36,30 +36,42 @@
   :type 'string
   :group 'lsp-clangd)
 
+(defvar-local lsp-clangd-launch-directory
+  nil
+  "If set, this variable is where clangd is started.")
+
+(put 'lsp-clangd-launch-directory 'safe-local-variable #'stringp)
+
+(defun lsp-clangd-make-traverser (filename)
+  "Unless lsp-clangd-launch-directory is set, walk upward from the current directory to FILENAME.
+Use lsp-clangd-executable to do so."
+  (or lsp-clangd-launch-directory
+      (lsp-make-traverser filename)))
+
 (lsp-define-stdio-client lsp-clangd-c++
                          "cpp"
-                         (lsp-make-traverser "compile_commands.json")
+                         (lsp-clangd-make-traverser "compile_commands.json")
                          (list lsp-clangd-executable)
                          :ignore-regexps
                          '("^Error -[0-9]+: .+$"))
 
 (lsp-define-stdio-client lsp-clangd-c
                          "c"
-                         (lsp-make-traverser "compile_commands.json")
+                         (lsp-clangd-make-traverser "compile_commands.json")
                          (list lsp-clangd-executable)
                          :ignore-regexps
                          '("^Error -[0-9]+: .+$"))
 
 (lsp-define-stdio-client lsp-clangd-objc
                          "objective-c"
-                         (lsp-make-traverser "compile_commands.json")
+                         (lsp-clangd-make-traverser "compile_commands.json")
                          (list lsp-clangd-executable)
                          :ignore-regexps
                          '("^Error -[0-9]+: .+$"))
 
 (lsp-define-stdio-client lsp-clangd-objc++
                          "objective-cpp"
-                         (lsp-make-traverser "compile_commands.json")
+                         (lsp-clangd-make-traverser "compile_commands.json")
                          (list lsp-clangd-executable)
                          :ignore-regexps
                          '("^Error -[0-9]+: .+$"))

--- a/lsp-clangd.el
+++ b/lsp-clangd.el
@@ -45,8 +45,8 @@
 (defun lsp-clangd-make-traverser (filename)
   "Unless lsp-clangd-launch-directory is set, walk upward from the current directory to FILENAME.
 Use lsp-clangd-executable to do so."
-  (or lsp-clangd-launch-directory
-      (lsp-make-traverser filename)))
+  (lambda () (or lsp-clangd-launch-directory
+            (lsp-make-traverser filename))))
 
 (lsp-define-stdio-client lsp-clangd-c++
                          "cpp"


### PR DESCRIPTION
Because of how people use cmake, you might never know where the `compile_commands.json` file is. I think its a better idea to allow the user to choose for the buffer what it will be, especially because it can be easily set via .dir-local.el.

Thank you!